### PR TITLE
[fix] Downloading more than 30 videos

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ async function createKS(adminSecret, partnerId) {
 }
 
 async function getMediasFromCategory(ks, categoryID) {
-    let response = await fetch(`https://api.cast.switch.ch/api_v3/service/media/action/list?ks=${ks}&filter[categoriesIdsMatchAnd]=${categoryID}&filter[objectType]=KalturaMediaEntryFilter&format=1`)
+    let response = await fetch(`https://api.cast.switch.ch/api_v3/service/media/action/list?ks=${ks}&filter[categoriesIdsMatchAnd]=${categoryID}&filter[objectType]=KalturaMediaEntryFilter&format=1&pager[pageSize]=500`)
     let data = await response.json()
     return data
 }


### PR DESCRIPTION
The problem was that the kaltura API returns only 30 medias par page. It now can return 500 par page so it should do the job.

close #8 